### PR TITLE
Update kparams

### DIFF
--- a/coverage.txt
+++ b/coverage.txt
@@ -4,8 +4,8 @@ yuca/__init__.py                       0      0   100%
 yuca/activations.py                  198     36    82%
 yuca/ca/__init__.py                    4      0   100%
 yuca/ca/common.py                    132     20    85%
-yuca/ca/continuous.py                373     35    91%
-yuca/ca/neural.py                    142     16    89%
+yuca/ca/continuous.py                381     35    91%
+yuca/ca/neural.py                    149     17    89%
 yuca/ca/reaction_diffusion.py        151     16    89%
 yuca/clone.py                         83     13    84%
 yuca/configs.py                       89     21    76%
@@ -19,5 +19,5 @@ yuca/wrappers/glider_wrapper.py       88     12    86%
 yuca/wrappers/halting_wrapper.py     182     28    85%
 yuca/wrappers/random_wrapper.py       16      4    75%
 ------------------------------------------------------
-TOTAL                               1929    268    86%
-message: with updated dependences, future 0.18.2->0.18.3 and torch 1.13.1->2.0.1
+TOTAL                               1944    269    86%
+no additional message

--- a/coverage.txt
+++ b/coverage.txt
@@ -20,4 +20,4 @@ yuca/wrappers/halting_wrapper.py     182     28    85%
 yuca/wrappers/random_wrapper.py       16      4    75%
 ------------------------------------------------------
 TOTAL                               1944    269    86%
-no additional message
+message: update test_neural to use the same kernel_params test as test_continuous (per review comment)

--- a/testing/yuca/ca/test_continuous.py
+++ b/testing/yuca/ca/test_continuous.py
@@ -227,6 +227,37 @@ class TestCCA(unittest.TestCase):
                     self.assertEqual(param[1].device.type, \
                             torch.device(my_device).type)
 
+    def test_kernel_params_config(self):
+
+        cca = CCA()
+
+        cca.restore_config("geminium.npy")
+        kparams = 1.0 * cca.kernel_params
+
+        ca_config = cca.make_config()
+
+        kconfig = ca_config["neighborhood_kernel_config"]
+        kconfig_params = kconfig["kernel_kwargs"]["parameters"]
+
+        # should contain the same info
+        self.assertEqual(kconfig_params.shape, kparams.shape)
+
+        self.assertEqual(0.0, np.sum(np.abs(kconfig_params - kparams).numpy()))
+
+    def test_kernel_params(self):
+
+        cca = CCA()
+
+        cca.restore_config("orbium.npy")
+        old_kparams = 1.0 * cca.kernel_params
+
+        cca.restore_config("geminium.npy")
+        new_kparams = 1.0 * cca.kernel_params
+
+        # orbium has a neighborhood kernel with a single Gaussian
+        # Hydrogeminium natans has one with multiple (3) rings 
+        self.assertNotEqual(old_kparams.shape, new_kparams.shape)
+
 
 if __name__ == "__main__": #pragma: no cover
 

--- a/testing/yuca/ca/test_continuous.py
+++ b/testing/yuca/ca/test_continuous.py
@@ -231,18 +231,27 @@ class TestCCA(unittest.TestCase):
 
         cca = CCA()
 
-        cca.restore_config("geminium.npy")
-        kparams = 1.0 * cca.kernel_params
+        for config_filepath in ["orbium.npy", "geminium.npy", "s643.npy"]:
+            cca.restore_config(config_filepath)
+            kparams = 1.0 * cca.kernel_params
+            ca_config = cca.make_config()
 
-        ca_config = cca.make_config()
+            kconfig = ca_config["neighborhood_kernel_config"]
+            kernel_kwargs = kconfig["kernel_kwargs"]
 
-        kconfig = ca_config["neighborhood_kernel_config"]
-        kconfig_params = kconfig["kernel_kwargs"]["parameters"]
+            kconfig_params = None
 
-        # should contain the same info
-        self.assertEqual(kconfig_params.shape, kparams.shape)
+            for key in kernel_kwargs.keys():
+                if kconfig_params is None:
+                    kconfig_params = np.array(kernel_kwargs[key])
+                else:
+                    kconfig_params = np.append(kconfig_params, \
+                            np.array(kernel_kwargs[key]))
 
-        self.assertEqual(0.0, np.sum(np.abs(kconfig_params - kparams).numpy()))
+            # should contain the same info
+            self.assertEqual(kconfig_params.shape, kparams.shape)
+
+            self.assertEqual(0.0, np.sum(np.abs(np.array(kconfig_params - kparams))))
 
     def test_kernel_params(self):
 

--- a/testing/yuca/ca/test_neural.py
+++ b/testing/yuca/ca/test_neural.py
@@ -206,7 +206,14 @@ class TestNCA(unittest.TestCase):
         ca_config = nca.make_config()
 
         kconfig = ca_config["neighborhood_kernel_config"]
-        kconfig_params = kconfig["kernel_kwargs"]["parameters"]
+        kconfig_params = None
+
+        for key in kernel_kwargs.keys():
+            if kconfig_params is None:
+                kconfig_params = np.array(kernel_kwargs[key])
+            else:
+                kconfig_params = np.append(kconfig_params, \
+                        np.array(kernel_kwargs[key]))
 
         # should contain the same info
         self.assertEqual(kconfig_params.shape, kparams.shape)

--- a/testing/yuca/ca/test_neural.py
+++ b/testing/yuca/ca/test_neural.py
@@ -206,6 +206,7 @@ class TestNCA(unittest.TestCase):
         ca_config = nca.make_config()
 
         kconfig = ca_config["neighborhood_kernel_config"]
+        kernel_kwargs = kconfig["kernel_kwargs"]
         kconfig_params = None
 
         for key in kernel_kwargs.keys():

--- a/testing/yuca/ca/test_neural.py
+++ b/testing/yuca/ca/test_neural.py
@@ -197,6 +197,22 @@ class TestNCA(unittest.TestCase):
                     self.assertEqual(param[1].device.type, \
                             torch.device(my_device).type)
 
+    def test_kernel_params_config(self):
+
+        nca = NCA()
+
+        kparams = 1.0 * nca.kernel_params
+
+        ca_config = nca.make_config()
+
+        kconfig = ca_config["neighborhood_kernel_config"]
+        kconfig_params = kconfig["kernel_kwargs"]["parameters"]
+
+        # should contain the same info
+        self.assertEqual(kconfig_params.shape, kparams.shape)
+
+        self.assertEqual(0.0, np.sum(np.abs(kconfig_params - kparams).numpy()))
+
 
 if __name__ == "__main__": #pragma: no cover
 

--- a/testing/yuca/ca/test_neural.py
+++ b/testing/yuca/ca/test_neural.py
@@ -211,7 +211,7 @@ class TestNCA(unittest.TestCase):
         # should contain the same info
         self.assertEqual(kconfig_params.shape, kparams.shape)
 
-        self.assertEqual(0.0, np.sum(np.abs(kconfig_params - kparams).numpy()))
+        self.assertEqual(0.0, np.sum(np.abs(np.array(kconfig_params - kparams))))
 
 
 if __name__ == "__main__": #pragma: no cover

--- a/yuca/ca/continuous.py
+++ b/yuca/ca/continuous.py
@@ -139,7 +139,8 @@ class CCA(CA):
 
         self.neighborhood_kernel_config = config["neighborhood_kernel_config"]
         nbhd_kernel = get_kernel(self.neighborhood_kernel_config)
-        self.update_kernel_params(self.neighborhood_kernel_config["kernel_kwargs"])
+        if "kernel_kwargs" in self.neighborhood_kernel_config.keys():
+            self.update_kernel_params(self.neighborhood_kernel_config["kernel_kwargs"])
 
         self.add_neighborhood_kernel(nbhd_kernel)
         self.initialize_neighborhood_layer()

--- a/yuca/ca/continuous.py
+++ b/yuca/ca/continuous.py
@@ -99,6 +99,18 @@ class CCA(CA):
         
         self.t_count = 0.0
 
+    def update_kernel_params(self, kernel_kwargs):
+
+        self.kernel_params = None
+
+        for key in kernel_kwargs.keys():
+            if self.kernel_params is None:
+                self.kernel_params = np.array(kernel_kwargs[key])
+            else:
+                self.kernel_params = np.append(self.kernel_params, \
+                        np.array(kernel_kwargs[key]))
+        
+        
     def change_kernel_radius(self, radius):
         """
 
@@ -125,8 +137,9 @@ class CCA(CA):
 
         self.initialize_id_layer()
 
-        nbhd_kernel = get_kernel(config["neighborhood_kernel_config"])
         self.neighborhood_kernel_config = config["neighborhood_kernel_config"]
+        nbhd_kernel = get_kernel(self.neighborhood_kernel_config)
+        self.update_kernel_params(self.neighborhood_kernel_config["kernel_kwargs"])
 
         self.add_neighborhood_kernel(nbhd_kernel)
         self.initialize_neighborhood_layer()
@@ -198,6 +211,7 @@ class CCA(CA):
             else:
                 neighborhood_kernel_config["kernel_kwargs"] = {}
             neighborhood_kernel_config["radius"] = self.kernel_radius
+
 
 
         else:

--- a/yuca/ca/neural.py
+++ b/yuca/ca/neural.py
@@ -60,6 +60,17 @@ class NCA(CA):
         self.default_init()
         self.reset()
 
+    def update_kernel_params(self, kernel_kwargs):
+
+        self.kernel_params = None
+
+        for key in kernel_kwargs.keys():
+            if self.kernel_params is None:
+                self.kernel_params = np.array(kernel_kwargs[key])
+            else:
+                self.kernel_params = np.append(self.kernel_params, \
+                        np.array(kernel_kwargs[key]))
+
     def default_init(self):
 
         self.add_identity_kernel()
@@ -109,8 +120,9 @@ class NCA(CA):
 
         self.initialize_id_layer()
 
-        nbhd_kernel = get_kernel(config["neighborhood_kernel_config"])
         self.neighborhood_kernel_config = config["neighborhood_kernel_config"]
+        self.update_kernel_params(self.neighborhood_kernel_config["kernel_kwargs"])
+        nbhd_kernel = get_kernel(self.neighborhood_kernel_config)
 
         self.add_neighborhood_kernel(nbhd_kernel)
         self.initialize_neighborhood_layer()
@@ -172,7 +184,7 @@ class NCA(CA):
             neighborhood_kernel_config = {}
             neighborhood_kernel_config["name"] = "GaussianMixture"
             params = self.get_params()
-            kernel_kwargs = {"parameters": params[-self.kernel_peaks*2:]}
+            kernel_kwargs = {"parameters": params[-self.kernel_peaks*3:]}
             neighborhood_kernel_config["kernel_kwargs"] = kernel_kwargs
 
             neighborhood_kernel_config["radius"] = self.kernel_radius

--- a/yuca/ca/neural.py
+++ b/yuca/ca/neural.py
@@ -172,7 +172,7 @@ class NCA(CA):
             neighborhood_kernel_config = {}
             neighborhood_kernel_config["name"] = "GaussianMixture"
             params = self.get_params()
-            kernel_kwargs = {"params": params[-self.kernel_peaks*2:]}
+            kernel_kwargs = {"parameters": params[-self.kernel_peaks*2:]}
             neighborhood_kernel_config["kernel_kwargs"] = kernel_kwargs
 
             neighborhood_kernel_config["radius"] = self.kernel_radius


### PR DESCRIPTION
This PR addresses the disconnect between the `kernel_params` class variable for ca and the kernel parameters in  `neighborhood_kernel_config["kernel_kwargs"]` in ca configs. (Issue #56 )